### PR TITLE
fix connection url composition

### DIFF
--- a/src/kbc.py
+++ b/src/kbc.py
@@ -8,8 +8,9 @@ import time
 import os
 import Exceptions
 from logger import debug
+from urllib.parse import urljoin
 
-connectionIndexUrl = os.environ['KBC_URL'] + '/v2/storage'
+connectionIndexUrl = urljoin(os.environ['KBC_URL'], '/v2/storage')
 http = httplib2.Http()
 
 def getProjectFeatures(token):

--- a/src/kbc.py
+++ b/src/kbc.py
@@ -8,7 +8,7 @@ import time
 import os
 import Exceptions
 from logger import debug
-from urllib.parse import urljoin
+from urlparse import urljoin
 
 connectionIndexUrl = urljoin(os.environ['KBC_URL'], '/v2/storage')
 http = httplib2.Http()


### PR DESCRIPTION
debug https://keboolaglobal.slack.com/archives/C0553EM2RGX/p1683646594611759
Na [zendesku](https://keboola.zendesk.com/agent/tickets/27901) som narazil na to ze zakaznik ktory pusta TDE exporter na starej fronte, mu potom spadne upload do Tableau servru ale uz hned na prvom api call na tokens verify. 
```
{"error":"Argument \\"id\\" is expected to be type \\"int\\", value \\"verify\\" given.","exceptionId":"kbc-us-east-1-connection-87e84e9a02e9c74967135270c1deecf2"}'
```
To bude zrejme nedavnou zmenou na connection kde uz nepodporuju double slash v ceste, `"[GET] [//v2/storage/tokens/verify]",` 
Problem je zrejme v tom ze v `connectionIndexUrl = os.environ['KBC_URL'] + '/v2/storage'` KBC_URL obsahuje slash na konci. Nepodarilo sa mi to overit (pustil som kontajner len na novej fronte a tam to nespadlo) ale pre istotu skusim takyto naslepo fix ktory by mal tento pripad poriesit. 